### PR TITLE
Fixed position set to [0,0] bug

### DIFF
--- a/parchmint/component.py
+++ b/parchmint/component.py
@@ -37,6 +37,7 @@ class Component:
         Raises:
             Exception: [description]
         """
+
         self.name: str = name
         self.ID: str = ID
         self.params = params
@@ -45,8 +46,8 @@ class Component:
         self.yspan: int = yspan
         self._ports: List[Port] = ports_list if ports_list else []
         self.layers: List[Layer] = layers if layers else []
-        self.xpos = xpos
-        self.ypos = ypos
+        self.xpos = params.data["position"][0]
+        self.ypos = params.data["position"][1]
 
     @property
     def ports(self) -> List[Port]:
@@ -98,7 +99,9 @@ class Component:
         Args:
             value (int): x coordianate of the object
         """
+
         if self.params.exists("position"):
+
             pos = self.params.get_param("position")
             pos[0] = value
             self.params.set_param("position", pos)


### PR DESCRIPTION
In component.py, the xpos setter on line 95 updates the position inside a component's parameters. When instantiating a component the following occurs:
1. We pass in the position of the component through the component's parameters rather than xpos and ypos
2. xpos and ypos are by default then set to [-1,-1]
3. The xpos and ypos setter then changes the component's parameters to match this (to the incorrect [-1,-1])

Only change to fix this is to change the constructor to set xpos,ypos based on the component's parameters to match the way we instantiate a component.